### PR TITLE
fix: 修复禁用redis缓存时项目启动错误

### DIFF
--- a/backend/src/modules/XiHan.BasicApp.Saas/Application/AppServices/Exporting/ExportTaskAppService.cs
+++ b/backend/src/modules/XiHan.BasicApp.Saas/Application/AppServices/Exporting/ExportTaskAppService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json;
 using XiHan.BasicApp.Saas.Application.Contracts;
 using XiHan.BasicApp.Saas.Application.Dtos;
@@ -28,18 +29,18 @@ public sealed class ExportTaskAppService
 
     private readonly IExportTaskRepository _repository;
 
-    private readonly IRedisDelayQueue<ExportTaskMessage> _exportTaskQueue;
+    private readonly IRedisDelayQueue<ExportTaskMessage>? _exportTaskQueue;
 
     private readonly IUnitOfWorkManager _unitOfWorkManager;
 
     /// <summary>
     /// 构造函数
     /// </summary>
-    public ExportTaskAppService(IExportTaskRepository repository, ICurrentUser currentUser, IRedisDelayQueue<ExportTaskMessage> exportTaskQueue, IUnitOfWorkManager unitOfWorkManager)
+    public ExportTaskAppService(IExportTaskRepository repository, ICurrentUser currentUser, IServiceProvider serviceProvider, IUnitOfWorkManager unitOfWorkManager)
     {
         _repository = repository;
         _currentUser = currentUser;
-        _exportTaskQueue = exportTaskQueue;
+        _exportTaskQueue = serviceProvider.GetService<IRedisDelayQueue<ExportTaskMessage>>();
         _unitOfWorkManager = unitOfWorkManager;
     }
 
@@ -77,17 +78,20 @@ public sealed class ExportTaskAppService
         // CreatedId（发起人）/ TenantId（发起租户）由审计 AOP 自动注入，后台据此重建上下文
         entity = await _repository.AddAsync(entity, cancellationToken);
 
-        // 提交后入队（延迟 0）：后台导出服务拉取后立即领取执行（替换原 3s 轮询）。无环境 UoW 时直接入队。
-        var taskId = entity.BasicId;
-        var message = new ExportTaskMessage { ExportTaskId = taskId, CreatedAt = DateTimeOffset.UtcNow };
-        var uow = _unitOfWorkManager.Current;
-        if (uow is not null)
+        // 提交后入队（延迟 0）：后台导出服务拉取后立即领取执行。Redis 未启用时跳过入队，仅落库。
+        if (_exportTaskQueue is not null)
         {
-            uow.OnCompleted(() => _exportTaskQueue.EnqueueAsync(message, TimeSpan.Zero));
-        }
-        else
-        {
-            await _exportTaskQueue.EnqueueAsync(message, TimeSpan.Zero, cancellationToken);
+            var taskId = entity.BasicId;
+            var message = new ExportTaskMessage { ExportTaskId = taskId, CreatedAt = DateTimeOffset.UtcNow };
+            var uow = _unitOfWorkManager.Current;
+            if (uow is not null)
+            {
+                uow.OnCompleted(() => _exportTaskQueue.EnqueueAsync(message, TimeSpan.Zero));
+            }
+            else
+            {
+                await _exportTaskQueue.EnqueueAsync(message, TimeSpan.Zero, cancellationToken);
+            }
         }
 
         return ToDto(entity);

--- a/backend/src/modules/XiHan.BasicApp.Saas/Infrastructure/Exporting/ExportTaskHostedService.cs
+++ b/backend/src/modules/XiHan.BasicApp.Saas/Infrastructure/Exporting/ExportTaskHostedService.cs
@@ -49,25 +49,31 @@ public sealed class ExportTaskMessage : IBackgroundTaskItem
 public sealed class ExportTaskHostedService : XiHanBackgroundServiceBase<ExportTaskHostedService>
 {
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly IRedisDelayQueue<ExportTaskMessage> _queue;
+    private readonly IRedisDelayQueue<ExportTaskMessage>? _queue;
 
     /// <summary>
     /// 构造函数
     /// </summary>
     public ExportTaskHostedService(
         IServiceScopeFactory scopeFactory,
-        IRedisDelayQueue<ExportTaskMessage> queue,
+        IServiceProvider serviceProvider,
         IOptions<XiHanBackgroundServiceOptions> options,
         ILogger<ExportTaskHostedService> logger)
         : base(logger, options, BuildConfig(options))
     {
         _scopeFactory = scopeFactory;
-        _queue = queue;
+        _queue = serviceProvider.GetService<IRedisDelayQueue<ExportTaskMessage>>();
     }
 
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        if (_queue is null)
+        {
+            Logger.LogWarning("Redis 未启用，ExportTaskHostedService 已跳过（Redis 延迟队列不可用）");
+            return;
+        }
+
         await RecoverPendingAsync(stoppingToken);
         await base.ExecuteAsync(stoppingToken);
     }

--- a/backend/src/modules/XiHan.BasicApp.Saas/Infrastructure/Messaging/DbMessageOutbox.cs
+++ b/backend/src/modules/XiHan.BasicApp.Saas/Infrastructure/Messaging/DbMessageOutbox.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using XiHan.BasicApp.Saas.Domain.Entities;
 using XiHan.BasicApp.Saas.Domain.Messaging;
 using XiHan.Framework.Caching.Distributed.Abstracts;
@@ -23,26 +24,35 @@ namespace XiHan.BasicApp.Saas.Infrastructure.Messaging;
 public sealed class DbMessageOutbox
 {
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly IRedisDelayQueue<MessageOutboxMessage> _queue;
+    private readonly IRedisDelayQueue<MessageOutboxMessage>? _queue;
     private readonly IUnitOfWorkManager _unitOfWorkManager;
+    private readonly ILogger<DbMessageOutbox> _logger;
 
     /// <summary>
     /// 构造函数
     /// </summary>
-    public DbMessageOutbox(IServiceScopeFactory scopeFactory, IRedisDelayQueue<MessageOutboxMessage> queue, IUnitOfWorkManager unitOfWorkManager)
+    public DbMessageOutbox(IServiceScopeFactory scopeFactory, IServiceProvider serviceProvider, IUnitOfWorkManager unitOfWorkManager, ILogger<DbMessageOutbox> logger)
     {
         _scopeFactory = scopeFactory;
-        _queue = queue;
+        _queue = serviceProvider.GetService<IRedisDelayQueue<MessageOutboxMessage>>();
         _unitOfWorkManager = unitOfWorkManager;
+        _logger = logger;
     }
 
     /// <summary>
     /// 入队待发送（SysEmail/SysSms 行已落库为 Pending）。在「事务提交后」入队，保证后台拉到时业务行已可见；无环境 UoW 时直接入队。
+    /// Redis 未启用时跳过入队。
     /// </summary>
     public Task EnqueueAsync(string channel, long entityId, CancellationToken cancellationToken = default)
     {
         if (entityId <= 0)
         {
+            return Task.CompletedTask;
+        }
+
+        if (_queue is null)
+        {
+            // Redis 未启用，延迟队列不可用，跳过入队
             return Task.CompletedTask;
         }
 

--- a/backend/src/modules/XiHan.BasicApp.Saas/Infrastructure/Messaging/MessageOutboxHostedService.cs
+++ b/backend/src/modules/XiHan.BasicApp.Saas/Infrastructure/Messaging/MessageOutboxHostedService.cs
@@ -57,25 +57,31 @@ public sealed class MessageOutboxHostedService : XiHanBackgroundServiceBase<Mess
     private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(30);
 
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly IRedisDelayQueue<MessageOutboxMessage> _queue;
+    private readonly IRedisDelayQueue<MessageOutboxMessage>? _queue;
 
     /// <summary>
     /// 构造函数
     /// </summary>
     public MessageOutboxHostedService(
         IServiceScopeFactory scopeFactory,
-        IRedisDelayQueue<MessageOutboxMessage> queue,
+        IServiceProvider serviceProvider,
         IOptions<XiHanBackgroundServiceOptions> options,
         ILogger<MessageOutboxHostedService> logger)
         : base(logger, options, BuildConfig(options))
     {
         _scopeFactory = scopeFactory;
-        _queue = queue;
+        _queue = serviceProvider.GetService<IRedisDelayQueue<MessageOutboxMessage>>();
     }
 
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        if (_queue is null)
+        {
+            Logger.LogWarning("Redis 未启用，MessageOutboxHostedService 已跳过（Redis 延迟队列不可用）");
+            return;
+        }
+
         await RecoverPendingAsync(stoppingToken);
         await base.ExecuteAsync(stoppingToken);
     }


### PR DESCRIPTION
<!-- 感谢贡献！提交前请阅读贡献指南，并完整填写以下内容。 -->

## 关联 Issue

无

## 变更类型


- [ ] feat：新功能
- [ √] fix：缺陷修复
- [ ] refactor：重构（非新功能、非缺陷）
- [ ] perf：性能优化
- [ ] docs：文档
- [ ] style：格式（不影响逻辑）
- [ ] test：测试
- [ ] build：构建 / 依赖
- [ ] ci：持续集成
- [ ] chore：杂项
- [ ] revert：回滚

## 变更说明

XiHan:Caching:Redis:IsEnabled=false 时，框架 XiHanCachingModule 不会注册 IRedisDelayQueue<> 及其实现 RedisDelayQueue<>（因为它强依赖 IConnectionMultiplexer），但应用层有多个服务无条件注入 IRedisDelayQueue<T>，导致 DI 容器在启动时解析失败。

## 影响范围

<!-- 侧别：后端（.NET / API） / 前端（Vue / 页面） / 前后端 / 部署 / 文档 -->
模块：Saas 

## 自测清单

- [ √] 后端 `dotnet build` 通过（如涉及后端）
- [ ] 前端 `pnpm build` / 类型检查 / lint 通过（如涉及前端）
- [ ] 已本地验证相关功能，无回归
- [ ] 未破坏现有 API 契约、权限码、路由 / 组件路径与 DTO 结构
- [ ] 涉及数据库结构变更已说明（本项目部署重建数据库，无需迁移脚本）
- [ ] 如为破坏性变更，已在下方「破坏性变更」中说明

## 破坏性变更

<!-- 如无请填「无」 -->

## 补充说明 / 截图

<img width="860" height="796" alt="image" src="https://github.com/user-attachments/assets/74653f41-d8bf-40d3-9cce-d1ca89a81ad7" />

错误日志
<img width="950" height="336" alt="0dd9eb7a9f3f6f9002ed9dc42e51bac5" src="https://github.com/user-attachments/assets/711fd238-2e22-4345-9422-6a85e051c522" />
